### PR TITLE
Bugfix : Set a field value to null

### DIFF
--- a/build/document.js
+++ b/build/document.js
@@ -69,7 +69,7 @@ var Document = (function () {
               Object.defineProperty(self, key, {
                 enumerable: true,
                 get: function () {
-                  return self.__newDoc[key] || self.__doc[key];
+                  return _.has(self.__newDoc, key) ? self.__newDoc[key] : self.__doc[key];
                 },
                 set: function (val) {
                   self.__newDoc[key] = val;

--- a/src/document.js
+++ b/src/document.js
@@ -58,7 +58,7 @@ class Document {
         Object.defineProperty(self, key, {
           enumerable: true,
           get: function() {
-            return self.__newDoc[key] || self.__doc[key];
+            return _.has(self.__newDoc, key) ? self.__newDoc[key] : self.__doc[key];
           },
           set: function(val) {
             self.__newDoc[key] = val;

--- a/test/units/document.test.js
+++ b/test/units/document.test.js
@@ -72,26 +72,31 @@ test['change props'] = {
     var d = this.d = new Document(123, {
       name: 'john',
       age: 23,
+      father: 'eric',
       hasKids: true
     });
 
     d.name.should.eql('john');
     d.age.should.eql(23);
+    d.father.should.eql('eric');
     d.hasKids.should.be.true;
 
     d.name = 'tim';
     d.mother = 'mary';
+    d.father = null;
   },
 
   'updated getters': function*() {
     this.d.name.should.eql('tim');
     this.d.mother.should.eql('mary');
+    should.equal(this.d.father, null);
   },
 
   'toJSON()': function*() {
     this.d.toJSON().should.eql({
       name: 'tim',
       mother: 'mary',
+      father: null,
       age: 23,
       hasKids: true
     });
@@ -100,7 +105,8 @@ test['change props'] = {
   'changes()': function*() {
     this.d.changes().should.eql({
       name: 'tim',
-      mother: 'mary'
+      mother: 'mary',
+      father: null
     });
   },
 
@@ -114,6 +120,7 @@ test['change props'] = {
     this.d.toJSON().should.eql({
       name: 'john',
       age: 23,
+      father: 'eric',
       hasKids: true
     })
   }


### PR DESCRIPTION
Hi,

Just a little bugfix. 

I have an issue if I load a document (or create a new one) and if I change the value of one field to null (or 0, false, undefined, empty string) changes() function doesn't return the edited field with a new empty value (he kept the previous value), and save() doesn't update the document properly.

Sorry for my poor english :)
Great project !