### PR TITLE
oplog.o2 field is being omitted

### DIFF
--- a/build/oplog.js
+++ b/build/oplog.js
@@ -335,7 +335,7 @@ var Oplog = (function (EventEmitter2) {
             return;
         }
 
-        this.emit([colName, opType], colName, opType, data.o);
+        this.emit([colName, opType], colName, opType, data.o, data.o2);
       },
       writable: true,
       configurable: true

--- a/src/oplog.js
+++ b/src/oplog.js
@@ -295,7 +295,7 @@ class Oplog extends EventEmitter2 {
         return;
     }
 
-    this.emit([colName, opType], colName, opType, data.o);
+    this.emit([colName, opType], colName, opType, data.o, data.o2);
   }
 }
 


### PR DESCRIPTION
Hello,

I have modified your library to send the oplog.o2 field on document updates, because we do not have enough information to identify the updated document without it when the update is applied using operators like $set.

For example, if you apply the following update:

`db.getCollection('tag').update({"_id": ObjectId("57237dd64945890e00f1c39c")}, {"$set":{"updatedAt":"2016-04-29T15:42:36.192Z"}})`

You have access only to this data:

`{"$set":{"updatedAt":"2016-04-29T15:42:36.192Z"}}`

Nevertheless, if you access to the oplog.o2 field, you have this extra important:

`{"_id":"57237dd64945890e00f1c39c"}`

As you can see, this information is very important and should be accessible.

Thank you very much.