### PR TITLE
Improved error handler overriding monk's onOpen event

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -9,6 +9,10 @@ var _ = require('lodash'),
   Database = require('./database');
 
 
+// Original monk.onOpen callback does not handle errors
+monk.prototype.onOpen = function (err, db) {
+  this.emit('open', err, db);
+};
 
 /**
  * All db connections.
@@ -37,27 +41,17 @@ class Manager {
 
     debug('connect to ' + url.join(', '));
 
-    let db = monk.apply(null, url);
-
     return new Q(function checkConnection(resolve, reject) {
-      var connectionTimeout = setTimeout(function() {
-        reject(new Error('Timed out connecting to db'));
-      }, options.timeout);
-
-      db.once('open', function() {
-        clearTimeout(connectionTimeout);
-
-        // until https://github.com/Automattic/monk/issues/24 is resolve we 
-        // manually check, see http://stackoverflow.com/questions/27547979/db-connection-error-handling-with-monk 
-        if (2 !== _.deepGet(db, 'driver._state')) {
-          reject(new Error('Failed to connect to db'));
-        } else {
-          var instance = new Database(db);
-
-          dbConnections.push(instance);
-
-          resolve(instance);
+      var monkOptions = {connectTimeoutMS: options.timeout};
+      var db = monk.call(null, url, monkOptions, function monkCallback(err, val) {
+        if (err) {
+          return reject(err);
         }
+
+        var instance = new Database(db);
+        dbConnections.push(instance);
+
+        resolve(instance);
       });
     });
   }

--- a/test/unit/manager.test.js
+++ b/test/unit/manager.test.js
@@ -36,7 +36,7 @@ test['connect'] = {
   },
   /**
    * TODO: Fix
-   * 
+   *
    * Test completes successfully but process hangs because handles not yet 
    * cleaned up...why not!? Initial investigation points to something in either 
    * Monk or mongodb node.js package - needs looking into
@@ -68,9 +68,9 @@ test['connect'] = {
     },
   },
   'replica set': function*() {
-    var db = yield Robe.connect(['127.0.0.1/robe-test/robe-test','localhost/robe-test']);
+    var db = yield Robe.connect(['127.0.0.1/robe-test','localhost/robe-test']);
 
-    db.should.be.instanceOf(Robe.Database);    
+    db.should.be.instanceOf(Robe.Database);
   },
 };
 


### PR DESCRIPTION
Latest robe's version is including monk's version `^0.9.1`. Sadly, this version is ignoring all the database problems thrown by mongodb driver.

manager.js ([monk@0.9.1](https://github.com/Automattic/monk/blob/0.9.1/lib/manager.js))
```
function Manager (uri, opts, fn) {
  ...
  this.driver.open(this.onOpen.bind(this));
 ...
}

...

Manager.prototype.onOpen = function () {
  this.emit('open');
};
```

This bug was solved in following versions, but they are not compatible due to refactors of internal properties checked by robe. For example:

oplog.js ([robe@master](https://github.com/hiddentao/robe/blob/master/src/oplog.js))
```
class Oplog extends EventEmitter2 {
  ...
  _resolveServerDb() {
    ...
    // find out master server
    var serverConfig = _.get(self.robeDb.db, 'driver._native.serverConfig', {});
   ...
  }
  ...
}
```

At this moment, robe is detecting errors using an approach of timeouts, but it is not an elegant solution and it is hiding real errors. For example:

manager.js ([robe@master](https://github.com/hiddentao/robe/blob/master/src/manager.js))
```
class Manager {
  ...
  static connect (url, options = {}) {
    ...
    var connectionTimeout = setTimeout(function() {
      reject(new Error('Timed out connecting to db'));
    }, options.timeout);
    ...
    if (2 !== _.deepGet(db, 'driver._state')) {
      reject(new Error('Failed to connect to db'));
    }
    ...
  }
  ...
}
```

After some research, I found a solution to fix that callback error without modifying dependencies. You can check I am overriding the monk's prototype to throw the errors and catch them in robe's manager.

manager.js ([robe@pullrequest](https://github.com/hiddentao/robe/pull/16))
```
monk.prototype.onOpen = function (err, db) {
  this.emit("open", err, db);
};
...
class Manager {
  static connect (url, options = {}) {
    ...
    var db = monk.call(null, url, monkOptions, function monkCallback(err, val) {
      ...
    });
    ...
  }
  ...
}
```

This change, beside avoid decoupled timeouts, provides the real error message thrown by mongodb and it facilitates debugging errors.